### PR TITLE
[Day-3] MockMvc 웹 통합 테스트 결과값의 CharacterEncoding UTF-8로 설정

### DIFF
--- a/app/src/test/java/com/codesoom/assignment/MockMvcCharacterEncodingCustomizer.java
+++ b/app/src/test/java/com/codesoom/assignment/MockMvcCharacterEncodingCustomizer.java
@@ -1,0 +1,19 @@
+package com.codesoom.assignment;
+
+import org.springframework.boot.test.autoconfigure.web.servlet.MockMvcBuilderCustomizer;
+import org.springframework.stereotype.Component;
+import org.springframework.test.web.servlet.setup.ConfigurableMockMvcBuilder;
+
+import java.nio.charset.StandardCharsets;
+
+/**
+ * MockMvc 테스트 결과값의 CharacterEncoding을 UTF-8로 설정합니다.
+ * 기본적으로 @AutoconfigureMockMvc를 통해 주입받는 상황에서만 적용됩니다.
+ */
+@Component
+class MockMvcCharacterEncodingCustomizer implements MockMvcBuilderCustomizer {
+    @Override
+    public void customize(ConfigurableMockMvcBuilder<?> builder) {
+        builder.alwaysDo(result -> result.getResponse().setCharacterEncoding(StandardCharsets.UTF_8.name()));
+    }
+}

--- a/app/src/test/java/com/codesoom/assignment/product/adapter/in/web/ProductControllerTest.java
+++ b/app/src/test/java/com/codesoom/assignment/product/adapter/in/web/ProductControllerTest.java
@@ -62,7 +62,6 @@ class ProductControllerTest {
 
                 mockMvc.perform(
                                 get("/products/" + productSource.getId())
-                                        .accept(MediaType.APPLICATION_JSON_UTF8)
                         )
                         .andExpect(status().isOk())
                         .andExpect(content().string(containsString(TOY_1.NAME())))
@@ -93,7 +92,6 @@ class ProductControllerTest {
         void it_responses_201() throws Exception {
             mockMvc.perform(
                             post("/products")
-                                    .accept(MediaType.APPLICATION_JSON_UTF8)
                                     .contentType(MediaType.APPLICATION_JSON)
                                     .content(JsonUtil.writeValue(TOY_1.요청_데이터_생성()))
                     )
@@ -122,7 +120,6 @@ class ProductControllerTest {
             void it_responses_200() throws Exception {
                 mockMvc.perform(
                                 put("/products/" + fixtureId)
-                                        .accept(MediaType.APPLICATION_JSON_UTF8)
                                         .contentType(MediaType.APPLICATION_JSON)
                                         .content(JsonUtil.writeValue(TOY_2.요청_데이터_생성()))
                         )


### PR DESCRIPTION
- @AutoconfigureMockMvc를 사용하여 MockMvc를 주입하는 경우에 한해서만 적용됨
- 관련 내용 [블로그](https://velog.io/@beomdrive/MockMvc-%ED%85%8C%EC%8A%A4%ED%8A%B8-%EC%8B%9C-%EC%9D%B8%EC%BD%94%EB%94%A9-%EB%AC%B8%EC%A0%9C%EB%A1%9C-%EA%B2%80%EC%A6%9D-%EC%8B%A4%ED%8C%A8) 작성